### PR TITLE
Add python to reqs in mira3

### DIFF
--- a/tools/mira3/mira.xml
+++ b/tools/mira3/mira.xml
@@ -1,5 +1,8 @@
-<tool id="mira_assembler" name="Assemble with MIRA v3.4" version="0.0.12">
+<tool id="mira_assembler" name="Assemble with MIRA v3.4" version="0.0.12+galaxy@VERSION_SUFFIX@">
     <description>Takes Sanger, Roche, Illumina, and Ion Torrent data</description>
+    <macros>
+        <token name="@VERSION_SUFFIX@">0</token>
+    </macros>
     <requirements>
         <requirement type="package" version="3.4.1.1">MIRA</requirement>
         <requirement type="package" version="3.11">python</requirement>

--- a/tools/mira3/mira.xml
+++ b/tools/mira3/mira.xml
@@ -2,6 +2,7 @@
     <description>Takes Sanger, Roche, Illumina, and Ion Torrent data</description>
     <requirements>
         <requirement type="package" version="3.4.1.1">MIRA</requirement>
+        <requirement type="package" version="3.11">python</requirement>
     </requirements>
     <version_command>
 python $__tool_directory__/mira.py -v

--- a/tools/mira3/mira.xml
+++ b/tools/mira3/mira.xml
@@ -1,4 +1,4 @@
-<tool id="mira_assembler" name="Assemble with MIRA v3.4" version="0.0.12+galaxy@VERSION_SUFFIX@">
+<tool id="mira_assembler" name="Assemble with MIRA v3.4" version="0.0.12+galaxy@VERSION_SUFFIX@" profile="24.0">
     <description>Takes Sanger, Roche, Illumina, and Ion Torrent data</description>
     <macros>
         <token name="@VERSION_SUFFIX@">0</token>
@@ -8,10 +8,10 @@
         <requirement type="package" version="3.11">python</requirement>
     </requirements>
     <version_command>
-python $__tool_directory__/mira.py -v
+python '$__tool_directory__/mira.py' -v
     </version_command>
     <command detect_errors="aggressive">
-python $__tool_directory__/mira.py mira '$out_fasta' '$out_qual' '$out_ace' '$out_caf' '$out_wig' '$out_log'
+python '$__tool_directory__/mira.py' mira '$out_fasta' '$out_qual' '$out_ace' '$out_caf' '$out_wig' '$out_log'
 ##Give the wrapper script list of output filenames, then the mira command...
 mira --job=$job_method,$job_type,$job_quality
 


### PR DESCRIPTION
Adding python to requirements. Since the container `quay.io/biocontainers/mira:3.4.1.1--1` has no python.

@peterjc I am not completely sure which versioning schema you are following. Could you please bump the version?